### PR TITLE
Change XSS oneline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export LHOST="http://localhost"; gau $1 | gf redirect | qsreplace "$LHOST" | xar
 > @cihanmehmet
 
 ```bash
-gospider -S targets_urls.txt -c 10 -d 5 --blacklist ".(jpg|jpeg|gif|css|tif|tiff|png|ttf|woff|woff2|ico|pdf|svg|txt)" --other-source | grep -e "code-200" | awk '{print $5}'| grep "=" | qsreplace -a | dalfox pipe > result.txt
+gospider -S targets_urls.txt -c 10 -d 5 --blacklist ".(jpg|jpeg|gif|css|tif|tiff|png|ttf|woff|woff2|ico|pdf|svg|txt)" --other-source | grep -e "code-200" | awk '{print $5}'| grep "=" | qsreplace -a | dalfox pipe | tee result.txt
 ```
 
 ### CVE-2020-5902

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export LHOST="http://localhost"; gau $1 | gf redirect | qsreplace "$LHOST" | xar
 > @cihanmehmet
 
 ```bash
-gospider -S targets_urls.txt -c 10 -d 5 --blacklist ".(jpg|jpeg|gif|css|tif|tiff|png|ttf|woff|woff2|ico|pdf|svg|txt)" --other-source | grep -e "code-200" | awk '{print $5}'| grep "=" | qsreplace -a | dalfox pipe -o result.txt
+gospider -S targets_urls.txt -c 10 -d 5 --blacklist ".(jpg|jpeg|gif|css|tif|tiff|png|ttf|woff|woff2|ico|pdf|svg|txt)" --other-source | grep -e "code-200" | awk '{print $5}'| grep "=" | qsreplace -a | dalfox pipe > result.txt
 ```
 
 ### CVE-2020-5902


### PR DESCRIPTION
from https://github.com/dwisiswant0/awesome-oneliner-bugbounty/issues/15 issue

Users who have installed with snapcraft are don't using to file i/o because they are subject to the snapcraft sandbox policy. tee command seems more suitable than the dalfox's -o option.
```
output file error (file)
output file error (write)
```

Please review :D

## Reference
https://snapcraft.io/docs/supported-interfaces