### PR TITLE
Updated certspotter API to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl -s "https://www.virustotal.com/ui/domains/domain.com/subdomains?limit=40" |
 ```
 
 ### Get Subdomains from CertSpotter
-> @pikpikcu
+> @nopantrootdance
 ```bash
 curl -s "https://certspotter.com/api/v1/issuances?domain=domain.com&include_subdomains=true&expand=dns_names" | jq .[].dns_names | tr -d '[]"\n ' | tr ',' '\n'
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ curl -s "https://www.virustotal.com/ui/domains/domain.com/subdomains?limit=40" |
 ### Get Subdomains from CertSpotter
 > @pikpikcu
 ```bash
-curl -s "https://certspotter.com/api/v0/certs?domain=domain.com" | grep -Po "((http|https):\/\/)?(([\w.-]*)\.([\w]*)\.([A-z]))\w+" | sort -u
+curl -s "https://certspotter.com/api/v1/issuances?domain=domain.com&include_subdomains=true&expand=dns_names" | jq .[].dns_names | tr -d '[]"\n ' | tr ',' '\n'
 ```
 
 ### Get Subdomains from Archive

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl -s "https://www.virustotal.com/ui/domains/domain.com/subdomains?limit=40" |
 ```
 
 ### Get Subdomains from CertSpotter
-> @nopantrootdance
+> @caryhooper
 ```bash
 curl -s "https://certspotter.com/api/v1/issuances?domain=domain.com&include_subdomains=true&expand=dns_names" | jq .[].dns_names | tr -d '[]"\n ' | tr ',' '\n'
 ```


### PR DESCRIPTION
When querying the CertSpotter API, I noticed the query failed.  API mentioned they migrated to v1.  After looking at their docs, I reformatted the query to pull from the new API without errors.  

Best,
Cary
@nopantrootdance