### PR TITLE
Fix RapidDNS subdomains enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ one | uniq); done
 > @andirrahmani1
 
 ```bash
-curl -s "https://rapiddns.io/subdomain/$1?full=1#result" | grep "<td><a" | cut -d '"' -f 2 | grep http | cut -d '/' -f3 | sed 's/#results//g' | sort -u
+export host="domain.com" ; curl -s "https://rapiddns.io/subdomain/$host?full=1#result" | grep -e "<td>.*$host</td>" | grep -oP '(?<=<td>)[^<]+' | sort -u
 ```
 
 ### Get Subdomains from BufferOver.run

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ one | uniq); done
 > @andirrahmani1
 
 ```bash
-export host="domain.com" ; curl -s "https://rapiddns.io/subdomain/$host?full=1#result" | grep -e "<td>.*$host</td>" | grep -oP '(?<=<td>)[^<]+' | sort -u
+export host="HOST" ; curl -s "https://rapiddns.io/subdomain/$host?full=1#result" | grep -e "<td>.*$host</td>" | grep -oP '(?<=<td>)[^<]+' | sort -u
 ```
 
 ### Get Subdomains from BufferOver.run


### PR DESCRIPTION
I think that rapidDNS response format has changed and the supplied command no longer worked.
I propose a new command which returns a clean output with all the subdomains from rapidDNS.